### PR TITLE
Fixing maven release action on existing version on main

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -121,14 +121,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          PRERELEASE_FLAG=""
-          if [[ "$VERSION" == *"-"* ]]; then
-            PRERELEASE_FLAG="--prerelease"
-          fi
           
-          # Create draft release with auto-generated notes
-          gh release create "v$VERSION" \
-            --title "Release $VERSION" \
-            --draft \
-            --generate-notes \
-            $PRERELEASE_FLAG
+          # Check if release already exists
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists"
+          else
+            PRERELEASE_FLAG=""
+            if [[ "$VERSION" == *"-"* ]]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+            
+            # Create draft release with auto-generated notes
+            gh release create "v$VERSION" \
+              --title "Release $VERSION" \
+              --draft \
+              --generate-notes \
+              $PRERELEASE_FLAG
+          fi


### PR DESCRIPTION
Changing release action for https://github.com/java-helpers/simple-builders/issues/61 to work even if version on main is already on target version.