### PR TITLE
Fixing verify step on maven release action

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -73,6 +73,8 @@ jobs:
           git tag -a "v$VERSION" -m "Release version $VERSION"
           
       - name: Build and verify
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
         run: mvn -B clean verify -Prelease
         
       - name: Deploy to Maven Central


### PR DESCRIPTION
Changing release action for https://github.com/java-helpers/simple-builders/issues/61 so that verification does not fail.