### PR TITLE
Run tests at deploy and require a manual publish gate for releases

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -92,13 +92,18 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
         run: mvn -B clean verify -Prelease
         
-      - name: Deploy to Maven Central
+      - name: Deploy (stage) to Maven Central
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
         run: |
-          mvn -B deploy -Prelease -pl core,processor -DskipTests=true -Dcentral.autoPublish=true
+          # Run tests against the artifacts being deployed (do NOT skip tests)
+          # and only STAGE the release to the Sonatype Central portal
+          # (autoPublish defaults to false). A maintainer must review and
+          # manually publish the staged deployment, so nothing is auto-released
+          # to Maven Central without human approval.
+          mvn -B deploy -Prelease -pl core,processor -Dcentral.autoPublish=false
           
       - name: Push changes to repository
         if: success()

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,16 +21,17 @@ Configure these GitHub secrets in **Settings** → **Secrets and variables** →
 2. Commits changes and creates tag `v0.2.0`
 3. Builds and verifies project with `-Prelease`
 4. Signs artifacts with GPG
-5. Deploys and **auto-publishes** to Maven Central
+5. Runs tests and **stages** the deployment to the Sonatype Central portal (does **not** auto-publish)
 6. Pushes commit and tag to `main`
 7. Creates **draft** GitHub release (requires manual publish)
 
 ## After Release
 
-1. **Publish GitHub Release**: Go to **Releases** → Edit draft → **Publish release**
-2. **Verify Maven Central**: Artifacts appear at https://central.sonatype.com/ (15-30 min delay)
+1. **Publish to Maven Central**: Go to the [Sonatype Central portal](https://central.sonatype.com/publishing/deployments), review the staged deployment, and **manually publish** it. Nothing is released to consumers until this step is performed.
+2. **Publish GitHub Release**: Go to **Releases** → Edit draft → **Publish release**
+3. **Verify Maven Central**: Artifacts appear at https://central.sonatype.com/ (15-30 min delay)
    - Search for: `io.github.java-helpers:simple-builders-core` or `simple-builders-processor`
-3. **Test the release**:
+4. **Test the release**:
    ```xml
    <dependency>
      <groupId>io.github.java-helpers</groupId>
@@ -64,6 +65,6 @@ mvn clean deploy -Prelease -Dcentral.autoPublish=true
 
 - Project uses [Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH)
 - Versions with `-` (e.g., `0.2.0-beta`) are marked as pre-releases
-- Auto-publish is **only enabled in GitHub Actions** by default
+- Releases are **staged** to the Sonatype Central portal and require a **manual publish** step; nothing is auto-released
 - Both `core` and `processor` modules are published to Maven Central
 - The `example` module is excluded from releases


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#2. Head branch: `AndreasIgel/simple-builders-fork:feature/155-deploy-tests-manual-publish` → base `java-helpers/simple-builders:main`.

## Summary

Removes two unsafe shortcuts in the Maven Central release deploy step.

Fixes #155

Before:
```yaml
mvn -B deploy -Prelease -pl core,processor -DskipTests=true -Dcentral.autoPublish=true
```
After:
```yaml
mvn -B deploy -Prelease -pl core,processor -Dcentral.autoPublish=false
```

- `-DskipTests=true` removed → the artifacts actually being deployed are now test-verified.
- `-Dcentral.autoPublish=true` replaced with `-Dcentral.autoPublish=false` → the release is only **staged** to the Sonatype Central portal; a maintainer must review and manually publish. Since Maven Central versions are immutable, this adds a human abort point before an irreversible public release.

`RELEASE.md` updated to describe the manual publish step (the module POM default `central.autoPublish` is already `false`, so this aligns the workflow with the documented/default behavior).

## Validation

Workflow + docs change; the Maven build is unaffected. Validated with `actionlint` (passes). The full release path itself requires Central/GPG secrets and cannot be executed locally. Scoped to todo #2 only.

Note: CI `build` and `dependency-review` checks fail for reasons unrelated to this change (fork lacks `SONAR_TOKEN`/`CODECOV_TOKEN` and Dependency graph is disabled on the fork).