### PR TITLE
SHA-pin all GitHub Actions across workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,11 +57,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Setup Java 17 for building the Maven project
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       if: matrix.language == 'java-kotlin'
       with:
         distribution: 'temurin'
@@ -70,7 +70,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -22,12 +22,12 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: '17'
           distribution: 'zulu'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,26 +25,26 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0  # Shallow clones should be disabled for better SonarCloud analysis
         
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: '17'
         distribution: 'zulu'
         cache: maven
 
     - name: Cache SonarCloud packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
         
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -83,7 +83,7 @@ jobs:
 
     - name: Upload JaCoCo HTML report (processor)
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: jacoco-report-html-processor
         path: processor/target/site/jacoco/
@@ -91,7 +91,7 @@ jobs:
 
     - name: Upload JaCoCo XML report (processor)
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: jacoco-report-xml-processor
         path: processor/target/site/jacoco/jacoco.xml


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#4. Head branch: `AndreasIgel/simple-builders-fork:feature/157-sha-pin-actions` → base `java-helpers/simple-builders:main`.

## Summary

Pins every third-party GitHub Action to an immutable commit SHA (supply-chain hardening), matching how the Codecov actions are already pinned.

Fixes #157

Mutable tags (`@v4`, `@v3`) can be repointed to malicious code that runs in CI with repo/secret access. Each `uses:` now references a full SHA with a `# vX.Y.Z` comment, keeping the current major version:

| Action | Pin |
| --- | --- |
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5` # v4.3.1 |
| actions/setup-java | `c1e323688fd81a25caa38c78aa6df2d33d3e20d9` # v4.8.0 |
| actions/cache | `0057852bfaa89a56745cba8c7296529d2fc39830` # v4.3.0 |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` # v4.6.2 |
| github/codeql-action (init+analyze) | `02c5e83432fe5497fd85b873b6c9f16a8578e1d9` # v3.37.0 |
| actions/dependency-review-action | `2031cfc080254a8a887f58cffee85186f0e49e48` # v4.9.0 |

Files: `maven.yml`, `codeql.yml`, `dependency-review.yml`, `maven-central-release.yml`. Complementary Dependabot `github-actions` ecosystem is added separately (todo #16) so pins keep getting security updates.

## Validation

Workflow-only change; Maven build unaffected. `actionlint` passes on all four workflows and no mutable `@vN` action refs remain.

Note: CI `build` and `dependency-review` checks fail for reasons unrelated to this change (fork lacks `SONAR_TOKEN`/`CODECOV_TOKEN`; Dependency graph disabled on the fork).