### PR TITLE
Document native dependency vulnerability scanning (Dependabot + Dependency Review)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,11 +34,18 @@ Security updates will be released as patch versions (e.g., 0.1.1) for the latest
 
 ## Dependencies
 
-We regularly update our dependencies to include security fixes. You can check for known vulnerabilities in our dependencies using:
+We keep dependencies patched and rely on GitHub's native supply-chain tooling
+rather than a stand-alone scanner:
 
-```bash
-mvn dependency-check:check
-```
+- **Dependabot** ([`.github/dependabot.yml`](.github/dependabot.yml)) opens
+  automated update PRs and, with Dependabot alerts enabled, continuously flags
+  known-vulnerable dependencies against the GitHub Advisory Database.
+- **Dependency Review** ([`.github/workflows/dependency-review.yml`](.github/workflows/dependency-review.yml))
+  runs on every pull request and **fails** it if it introduces a dependency with
+  a High (or greater) severity vulnerability or a disallowed license.
+
+Maintainers: ensure *Dependency graph*, *Dependabot alerts*, and *Dependabot
+security updates* are enabled under **Settings → Code security**.
 
 ## Best Practices
 


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#8. Head branch: `AndreasIgel/simple-builders-fork:feature/159-native-dependency-scanning` → base `java-helpers/simple-builders:main`.

## Summary

Makes the `SECURITY.md` dependency-scanning promise real using the **native GitHub stack**, instead of a stand-alone OWASP dependency-check gate.

Fixes #159

**Decision:** the OWASP dependency-check approach originally proposed in issue #159 was rejected after review (high false-positive rate from fuzzy CPE matching; NVD-API fragility — a trial CI run failed on an *NVD data update error*, not a real finding). This replaces PR #6 (now closed). I couldn't retitle/comment on the upstream issue (bot lacks write on `java-helpers/simple-builders`), so the rationale lives here.

`SECURITY.md` previously instructed `mvn dependency-check:check`, which never worked (no plugin configured). Replaced with a description of what the repo actually uses:
- **Dependabot** (`.github/dependabot.yml`) — update PRs + alerts against the GitHub Advisory Database.
- **Dependency Review** action — the PR gate (`fail-on-severity: high`, `deny-licenses`), enforced in the companion PR for todo #7 (issue #160).

Also notes the repo settings maintainers must enable (Dependency graph, Dependabot alerts, Dependabot security updates).

## Validation

- Docs-only change; no Maven or workflow impact. `mvn` build unaffected.


## Maintainer TODOs

- [x] Under **Settings → Code security**, enable **Dependency graph**, **Dependabot alerts**, and **Dependabot security updates** so the native supply-chain flow described in `SECURITY.md` (Dependabot + Dependency Review) actually runs. (Also noted inline in `SECURITY.md`.)