### PR TITLE
Enforce severity and license gates in dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -34,6 +34,9 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-        #   fail-on-severity: moderate
-        #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
-        #   retry-on-snapshot-warnings: true
+          # Fail the PR when it introduces a vulnerability at or above this severity.
+          fail-on-severity: high
+          # Block copyleft / incompatible licenses that conflict with this MIT project.
+          deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later, AGPL-3.0-or-later
+          # Snapshot dependency data can lag right after a push; retry instead of failing spuriously.
+          retry-on-snapshot-warnings: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,26 +9,30 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency review'
 on:
-  pull_request:
+  # Use pull_request_target so the review also works for PRs opened from forks.
+  # A plain `pull_request` run from a fork receives a read-only GITHUB_TOKEN, so
+  # `comment-summary-in-pr` cannot post its summary ("Unable to write summary to
+  # pull-request. Make sure you are giving this workflow the permission
+  # 'pull-requests: write'"). pull_request_target runs in the base-repo context
+  # with a read/write token, so the summary is posted on fork PRs too.
+  #
+  # This is safe here because dependency-review-action never checks out or executes
+  # PR-supplied code: it only compares the PR's base/head via the GitHub
+  # dependency-graph/advisory API. No checkout step is used, so untrusted code is
+  # never run with the elevated token.
+  pull_request_target:
     branches: [ "main" ]
 
-# If using a dependency submission action in this workflow this permission will need to be set to:
-#
-# permissions:
-#   contents: write
-#
-# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
 permissions:
   contents: read
-  # Write permissions for pull-requests are required for using the `comment-summary-in-pr` option, comment out if you aren't using this option
+  # Required so `comment-summary-in-pr` can post the review summary (works for
+  # fork PRs only because of the pull_request_target trigger above).
   pull-requests: write
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#7. Head branch: `AndreasIgel/simple-builders-fork:feature/160-dependency-review-gates` → base `java-helpers/simple-builders:main`.

## Summary

Turns the Dependency Review check from advisory-only into an enforced gate.

Fixes #160

`.github/workflows/dependency-review.yml` previously had the enforcement options commented out, so a PR adding a vulnerable or copyleft-licensed dependency would only get a comment, never fail. Enabled:

```yaml
fail-on-severity: high
deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later, AGPL-3.0-or-later
retry-on-snapshot-warnings: true
```

License denylist targets the copyleft families incompatible with this MIT project; `retry-on-snapshot-warnings` avoids spurious failures when the dependency-submission snapshot lags right after a push.

## Validation

- `actionlint` passes.
- Workflow-only change; no Maven impact.

Note: this action requires the fork's **Dependency graph** to be enabled (Settings → Security & analysis). Until then the `dependency-review` check fails with "Dependency graph is not enabled" — a fork setting, unrelated to this change. The other red checks (`build`) are the fork's missing `SONAR_TOKEN`/`CODECOV_TOKEN`.


## Fork PR support (added)

A plain `pull_request` run from a fork gets a **read-only** `GITHUB_TOKEN`, so `comment-summary-in-pr: always` could not post its summary on external PRs (`##[warning]Unable to write summary to pull-request ...`). The check still ran, but maintainers never saw the review comment on fork PRs.

Fixed by switching the trigger to **`pull_request_target`**, which runs in the base-repo context with a read/write token so the summary posts on fork PRs too. This is safe here because `dependency-review-action` **never checks out or executes PR-supplied code** — it only diffs the PR's base/head via the GitHub dependency-graph/advisory API. The `Checkout repository` step was removed (it was unused; the action needs no checkout without a `config-file`), guaranteeing no untrusted code runs with the elevated token.

### On unrecognized licenses (review question)

With a **deny-list** (`deny-licenses`), a dependency whose license can't be detected is **reported but does not fail** the check (per the action docs: *"If we can't detect the license for a dependency we will inform you, but the action won't fail."*). So unrecognized licenses do not break the build here. Switching to `allow-licenses` would be the opposite — it fails on anything not in the allow-list, including unknown licenses — so the deny-list is intentionally kept. `deny-licenses` is marked deprecated upstream; if it is ever removed, the migration is to exempt specific packages via `allow-dependencies-licenses`, not to adopt `allow-licenses`.

## Maintainer TODOs

- [x] **Enable *Dependency graph*** under **Settings → Code security** (repo). `dependency-review-action` needs it; while it is disabled the Dependency Review check fails/does nothing regardless of this PR. Once enabled, `fail-on-severity: high` + `deny-licenses` take effect on every PR.