### PR TITLE
Enable CodeQL security-extended and security-and-quality query packs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,10 @@ jobs:
         include:
         - language: actions
           build-mode: none
+          queries: security-extended,security-and-quality
         - language: java-kotlin
           build-mode: autobuild # CodeQL will automatically build the Maven project
+          queries: security-extended,security-and-quality
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -74,12 +76,10 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
+        # Run the extended security and code-quality query packs (see matrix above)
+        # in addition to the default suite, for higher-recall security analysis.
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        queries: ${{ matrix.queries }}
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above


### PR DESCRIPTION
## Summary

Enables the CodeQL `security-extended,security-and-quality` query packs in `.github/workflows/codeql.yml` (previously commented out), for both the `actions` and `java-kotlin` languages. The query set is supplied per language via a `queries` matrix entry and wired into the `github/codeql-action/init` step (`queries: ${{ matrix.queries }}`).

## Why

The default CodeQL suite runs a limited query set. For a library consumed at compile time in high-security/high-reliability environments, the extended security-and-quality packs materially increase recall of vulnerabilities and quality issues in both the Java code and the GitHub Actions workflows.

## Validation

Workflow-only change (no build impact); validated by review of the resulting `codeql.yml`.

Fixes #161


## Maintainer TODOs

- [ ] Ensure **Code scanning** is enabled (repo **Security → Code scanning**) so the CodeQL results (now using the `security-extended,security-and-quality` packs) are ingested and surfaced. Workflow-driven CodeQL works on public repos out of the box; this is just to confirm alerts appear.