### PR TITLE
Tighten coverage gates (require CI to pass; measure mapper logic)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
-  require_ci_to_pass: false
+  # Only report a passing coverage status when the CI build/tests actually pass,
+  # so a green Codecov check can't green-light a merge whose tests never ran.
+  require_ci_to_pass: true
 
 coverage:
   status:

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,10 @@
     <sonar.java.binaries>${project.basedir}/core/target/classes,${project.basedir}/processor/target/classes</sonar.java.binaries>
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/core/target/site/jacoco/jacoco.xml,${project.basedir}/processor/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.exclusions>**/example/**</sonar.exclusions>
-    <!-- Coverage exclusion needs to match jacoco configuration in processor module -->
-    <sonar.coverage.exclusions>**/*Mapper*.java,**/processor/model/**,**/processor/exceptions/**,**/generated/**</sonar.coverage.exclusions>
+    <!-- Coverage exclusion needs to match jacoco configuration in processor module.
+         Only genuine boilerplate is excluded (DTO model, exception classes, generated
+         sources); mapper logic is intentionally measured. -->
+    <sonar.coverage.exclusions>**/processor/model/**,**/exceptions/**,**/generated/**</sonar.coverage.exclusions>
     
     <!-- Plugin Versions -->
     <plugin.maven.compiler.version>3.13.0</plugin.maven.compiler.version>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -327,12 +327,10 @@
                 </goals>
                 <configuration>
                   <excludes>
-                    <!-- Exclude mapper utilities from coverage -->
-                    <exclude>**/*Mapper*.class</exclude>
                     <!-- Exclude DTOs (model package) from coverage -->
                     <exclude>**/processor/model/**</exclude>
                     <!-- Exclude exception classes from coverage (simple constructors) -->
-                    <exclude>**/processor/exceptions/**</exclude>
+                    <exclude>**/exceptions/**</exclude>
                   </excludes>
                 </configuration>
               </execution>


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#9. Head branch: `AndreasIgel/simple-builders-fork:feature/162-tighten-coverage-gates` → base `java-helpers/simple-builders:main`.

## Summary

Makes the coverage signal honest and enforced.

Fixes #162

- `codecov.yml`: `require_ci_to_pass: false` → `true`, so a passing coverage status can't be reported when the CI build/tests failed.
- Coverage exclusions: dropped the broad `**/*Mapper*` wildcard (it hid real code-generation logic — measured `RoasterMapper` ~69%, `JavaLangMapper` ~93%). Kept genuine boilerplate excluded (DTO `model` package, exception packages via `**/exceptions/**`, generated sources). `sonar.coverage.exclusions` (root `pom.xml`) and the JaCoCo `excludes` (`processor/pom.xml`) are kept in sync.

The 80% project target is retained: measured processor coverage stays ~93% with the mappers now included, so there's ample headroom without loosening.

## Validation

- `mvn -Pmetrics clean verify` passes; processor overall instruction coverage 93.2% with `RoasterMapper`/`JavaLangMapper` now present in the JaCoCo report and `RoasterMapperException` still excluded.
- `codecov.yml` is valid YAML.

Note (out of scope, flagged for follow-up): under local Maven 3.6.3 the **core** module's tests report "Tests run: 0" (core doesn't pin `maven-surefire-plugin` like `processor` does), so core shows 0% locally. This looks like an old default-surefire/JUnit5 discovery issue; happy to open a separate issue/PR to pin surefire in `core`.

Existing red checks (`build`, `dependency-review`) are the fork's missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph — unrelated.


## Maintainer TODOs

- [x] Confirm the **Codecov** integration/status is configured for the repo (it already posts PR comments, so this is a verification step). With `require_ci_to_pass: true`, Codecov only reports a passing status once CI actually passes — if you gate merges on the Codecov status, make sure it is added to branch protection.