### PR TITLE
Add timeout-minutes and concurrency groups to all workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,11 @@ on:
   schedule:
     - cron: '20 2 * * 2'
 
+# Cancel superseded runs for the same ref to save runner minutes.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -28,6 +33,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: 120
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Cancel superseded runs for the same PR to save runner minutes.
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #
 # permissions:
@@ -26,6 +31,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v4

--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -14,9 +14,16 @@ on:
         required: true
         type: string
 
+# Serialize releases: never run two release jobs at once, and never cancel an
+# in-progress release (cancelling mid-deploy could leave a partial publish).
+concurrency:
+  group: maven-central-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,10 +15,16 @@ on:
     branches: [ "main" ]
     types: [opened, synchronize, reopened]
 
+# Cancel superseded runs for the same ref to save runner minutes.
+concurrency:
+  group: maven-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#10. Head branch: `AndreasIgel/simple-builders-fork:feature/163-workflow-timeouts-concurrency` → base `java-helpers/simple-builders:main`.

## Summary

Adds the two resource guards missing from every workflow.

Fixes #163

- **`timeout-minutes`** on every job so a hung step can't run to the 6-hour default: `maven.yml` build 20, `codeql.yml` analyze 120, `dependency-review.yml` 10, `maven-central-release.yml` 30.
- **`concurrency`** group on every workflow:
  - CI/scan (`maven`, `codeql`, `dependency-review`) → group keyed on `github.ref` with `cancel-in-progress: true` (cancel superseded runs for the same ref).
  - `maven-central-release` → fixed group `maven-central-release` with `cancel-in-progress: false`, so releases serialize and an in-progress release is never cancelled mid-deploy (avoids a partial publish).

## Validation

- `actionlint` passes for all four workflows.
- Workflow-only change; no Maven impact.

Existing red checks (`build`, `dependency-review`) are the fork's missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph — unrelated to this change.