### PR TITLE
Drop unnecessary pull-requests: write scope from the Maven CI job

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,11 +19,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    # Least privilege: the build job only reads the repo and writes check
-    # output. No step uses the workflow token to write to pull requests, and
-    # SonarCloud/Codecov PR decoration is done server-side using tokens
-    # configured in their project settings (not the workflow GITHUB_TOKEN).
-    # This permission predates those integrations and is unused, so drop it.
+    # Least privilege: read the repository (checkout + build) and write
+    # check-run output (test/analysis results). No step uses the workflow
+    # token to write to pull requests.
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,8 +20,10 @@ jobs:
 
     runs-on: ubuntu-latest
     # Least privilege: the build job only reads the repo and writes check
-    # output. SonarCloud/Codecov PR decoration is done by their GitHub Apps,
-    # not the workflow token, so pull-requests: write is not needed here.
+    # output. No step uses the workflow token to write to pull requests, and
+    # SonarCloud/Codecov PR decoration is done server-side using tokens
+    # configured in their project settings (not the workflow GITHUB_TOKEN).
+    # This permission predates those integrations and is unused, so drop it.
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,9 +19,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # Least privilege: the build job only reads the repo and writes check
+    # output. SonarCloud/Codecov PR decoration is done by their GitHub Apps,
+    # not the workflow token, so pull-requests: write is not needed here.
     permissions:
       contents: read
-      pull-requests: write
       checks: write
 
     steps:


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#12. Head branch: `AndreasIgel/simple-builders-fork:feature/165-narrow-pr-write-scope` → base `java-helpers/simple-builders:main`.

## Summary

Applies least-privilege to the `build` job's `GITHUB_TOKEN`.

Fixes #165

The `build` job granted `pull-requests: write`, but no step uses the workflow token to write to PRs — SonarCloud and Codecov PR decoration/comments are done by their GitHub Apps with their own tokens. Removed the scope:

```yaml
permissions:
  contents: read
  checks: write        # pull-requests: write removed
```

This limits blast radius if a build step or third-party action is compromised. `pull-requests: write` remains where it is genuinely needed (the `dependency-review` workflow's PR summary comment).

## Validation

- `actionlint` passes.
- Workflow-only change; Maven build unaffected.

Red `build`/`dependency-review` checks on the fork are the missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph (unrelated to permission scope).