### PR TITLE
Rotate SonarCloud cache key with a content hash

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,8 +40,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
+        # Content-addressed so the cache rotates when project config changes,
+        # with a prefix fallback for warm restores.
+        key: ${{ runner.os }}-sonar-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-sonar-
         
     - name: Cache Maven packages
       uses: actions/cache@v4


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#13. Head branch: `AndreasIgel/simple-builders-fork:feature/166-sonar-cache-key-hash` → base `java-helpers/simple-builders:main`.

## Summary

Makes the SonarCloud cache self-refreshing.

Fixes #166

The cache key was static (`${{ runner.os }}-sonar`), so `~/.sonar/cache` was written once and only ever restored — the scanner engine/plugins never rotated and a poisoned entry would persist. Now content-addressed:

```yaml
key: ${{ runner.os }}-sonar-${{ hashFiles('**/pom.xml') }}
restore-keys: ${{ runner.os }}-sonar-
```

The `restore-keys` prefix still gives a warm restore when the hash changes.

## Validation

- `actionlint` passes.
- Workflow-only change; Maven build unaffected.

Red `build`/`dependency-review` checks are the fork's missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph — unrelated.