### PR TITLE
Align release workflow docs with its actual (workflow_dispatch) trigger

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -1,6 +1,7 @@
-# GitHub Action workflow for releasing artifacts to Maven Central
-# This workflow is triggered manually or on tag creation and handles:
-# - Version management from git tags
+# GitHub Action workflow for releasing artifacts to Maven Central.
+# Triggered manually via workflow_dispatch with an explicit release_version
+# input (there is no tag trigger). It handles:
+# - Version management from the release_version input (not from git tags)
 # - GPG signing of artifacts
 # - Deployment to Maven Central via Sonatype
 


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#15. Head branch: `AndreasIgel/simple-builders-fork:feature/168-release-doc-trigger-align` → base `java-helpers/simple-builders:main`.

## Summary

Fixes a documentation/behavior mismatch in the release workflow header.

Fixes #168

The header claimed the workflow is tag-triggered with the version derived from git tags, but the only trigger is a manual `workflow_dispatch` with a `release_version` input:

```diff
-# This workflow is triggered manually or on tag creation and handles:
-# - Version management from git tags
+# Triggered manually via workflow_dispatch with an explicit release_version
+# input (there is no tag trigger). It handles:
+# - Version management from the release_version input (not from git tags)
```

Comment-only change; the trigger and job logic are unchanged. Misleading release docs invite operator error on the most safety-critical workflow (e.g. pushing a tag expecting a publish).

## Validation

- `actionlint` passes.

Red `build`/`dependency-review` checks on the fork are the missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph — unrelated.