### PR TITLE
Track github-actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,20 @@
 version: 2
 updates:
+  # Keep the GitHub Actions used in the workflows up to date. This matters most
+  # once actions are SHA-pinned: a pinned SHA never gets security updates on its
+  # own, so Dependabot opens PRs that bump the pinned SHAs as new releases land.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "maven" # See documentation for possible values
     directories:
       - "/core"


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#16. Head branch: `AndreasIgel/simple-builders-fork:feature/169-dependabot-github-actions` → base `java-helpers/simple-builders:main`.

## Summary

Adds the `github-actions` ecosystem to Dependabot so the actions used in the workflows receive automated updates.

Fixes #169

Only `maven` was configured. This is independent of the project being a Maven project — and it matters most now that the workflows are SHA-pinned: a pinned SHA never gets a security update on its own, so without this Dependabot block a vulnerable pinned action would silently persist.

```yaml
- package-ecosystem: "github-actions"
  directory: "/"          # covers .github/workflows
  schedule:
    interval: "weekly"
  labels: ["dependencies", "github-actions"]
  groups:
    github-actions:
      patterns: ["*"]     # one grouped PR to reduce noise
```

## Validation

- YAML parses; both ecosystems present (`github-actions`, `maven`).

Red `build`/`dependency-review` checks on the fork are the missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph — unrelated.