### PR TITLE
Use private vulnerability reporting instead of public issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,18 @@ If you discover a security vulnerability in Simple Builders, we appreciate your 
 
 ### How to Report
 
-Please report security issues by [opening a new issue](https://github.com/java-helpers/simple-builders/issues) on GitHub.
+**Please do not report security vulnerabilities through public GitHub issues.**
+Doing so discloses an unpatched issue to attackers before a fix is available.
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Open the repository's [**Security** tab](https://github.com/java-helpers/simple-builders/security).
+2. Click **Report a vulnerability** to file a private
+   [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+   visible only to you and the maintainers.
+
+> Maintainers: enable *Private vulnerability reporting* under
+> **Settings → Code security** so the button above is available to reporters.
 
 ### What to Include
 


### PR DESCRIPTION
> Upstream counterpart of fork PR AndreasIgel/simple-builders-fork#17. Head branch: `AndreasIgel/simple-builders-fork:feature/170-private-vuln-reporting` → base `java-helpers/simple-builders:main`.

## Summary

Replaces the public-issue disclosure instruction in `SECURITY.md` with GitHub's private vulnerability reporting.

Fixes #170

`SECURITY.md` previously told reporters to open a **public** GitHub issue — which discloses an unpatched vulnerability to attackers before a fix exists. Now it directs them to **Security → Report a vulnerability** (a private GitHub Security Advisory) and explicitly forbids public issues, with a maintainer note to enable *Private vulnerability reporting* under Settings → Code security.

## Validation

- Docs-only change; Maven build unaffected.

Red `build`/`dependency-review` checks on the fork are the missing `SONAR_TOKEN`/`CODECOV_TOKEN` and disabled Dependency graph — unrelated.


## Maintainer TODOs

- [x] **Enable *Private vulnerability reporting*** under **Settings → Code security** so the "Report a vulnerability" button referenced by the updated `SECURITY.md` is available to reporters. (Also noted inline in `SECURITY.md`.)