### PR TITLE
Bump core/processor dependency versions (roaster, jackson-databind, junit)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,7 +65,7 @@
     <central.autoPublish>false</central.autoPublish>
     
     <!-- Dependency Versions -->
-    <junit-jupiter.version>6.0.3</junit-jupiter.version>
+    <junit-jupiter.version>6.1.2</junit-jupiter.version>
     <apache-commons-lang3.version>3.20.0</apache-commons-lang3.version>
     
     <!-- Plugin Versions -->

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -54,12 +54,12 @@
     
     <!-- Dependency Versions -->
     <auto-service.version>1.1.1</auto-service.version>
-    <roaster.version>2.31.0.Final</roaster.version>
+    <roaster.version>2.31.1.Final</roaster.version>
     <commons-lang.version>3.20.0</commons-lang.version>
     <commons-collections.version>4.5.0</commons-collections.version>
-    <junit-jupiter.version>6.0.3</junit-jupiter.version>
+    <junit-jupiter.version>6.1.2</junit-jupiter.version>
     <google-compile-testing.version>0.23.0</google-compile-testing.version>
-    <jackson-databind.version>2.21.1</jackson-databind.version>
+    <jackson-databind.version>2.22.1</jackson-databind.version>
     
     <!-- Java and Compiler Properties -->
     <java.version>17</java.version>


### PR DESCRIPTION
## Summary

Refreshes outdated dependency versions in the `core` and `processor` modules, based on a `mvn versions:display-dependency-updates` audit:

- `org.jboss.forge.roaster:roaster-api` / `roaster-jdt`: `2.31.0.Final` → `2.31.1.Final` (shipped runtime dependency of the processor)
- `com.fasterxml.jackson.core:jackson-databind` (test): `2.21.1` → `2.22.1`
- `org.junit.jupiter:*` (test): `6.0.3` → `6.1.2`

`commons-lang3`, `commons-collections4`, `auto-service` and `compile-testing` are already current. No known CVE affects the previously pinned versions; the meaningful bump is the Roaster runtime dependency.

## Validation

`mvn clean verify` — green (283 processor tests).

Fixes #174
