### PR TITLE
Allow manual runs of CI and CodeQL via workflow_dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '20 2 * * 2'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches: [ "main" ]
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #203

## Summary
Adds a `workflow_dispatch:` trigger to the CI and CodeQL workflows so maintainers can start them manually from the Actions tab (a "Run workflow" button), without pushing an artificial commit.

```diff
# .github/workflows/maven.yml  and  .github/workflows/codeql.yml
 on:
   push: ...
   pull_request: ...
+  workflow_dispatch:
```

## Scope / rationale
- Purely additive — existing `push` / `pull_request` (and CodeQL `schedule`) triggers are unchanged.
- Useful for re-running the security scan / full build+coverage on demand after config changes (secrets, branch protection, scanner settings) or for incident response. Mirrors the release workflow, which already has `workflow_dispatch`.
- `dependency-review.yml` is intentionally **excluded**: `dependency-review-action` needs a base/head to diff and errors on a plain `workflow_dispatch` run unless explicit `base-ref`/`head-ref` inputs are wired (out of scope).

## Validation
- `actionlint` clean on both workflows.


## Related

The fork-PR quality workflows added in #186 (`fork-coverage.yml`, `fork-sonar.yml`) carry their own `workflow_dispatch` trigger (with a `run_id` input) in that PR, since those files live on #186's branch. This PR covers the manual trigger for `maven.yml` and `codeql.yml`.