### PR TITLE
Exclude bot-authored PRs from Sonar/Codecov secret steps

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -121,8 +121,11 @@ jobs:
         if-no-files-found: warn
 
     - name: SonarCloud Analysis
-      # Skip when SONAR_TOKEN is unavailable (fork/Dependabot PRs).
-      if: env.SONAR_TOKEN != ''
+      # Skip when SONAR_TOKEN is unavailable (fork PRs) and for any bot-authored
+      # PR (Dependabot, Renovate, ...). The bot check uses the PR author's
+      # account type rather than a hard-coded login, and is not defeated by a
+      # maintainer re-run (which would otherwise make the withheld token appear).
+      if: env.SONAR_TOKEN != '' && github.event.pull_request.user.type != 'Bot'
       run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --file pom.xml
 
     - name: Upload JaCoCo HTML report (processor)
@@ -174,8 +177,8 @@ jobs:
         if-no-files-found: warn
 
     - name: Upload test results to Codecov (processor)
-      # Skip when CODECOV_TOKEN is unavailable (fork/Dependabot PRs).
-      if: always() && env.CODECOV_TOKEN != ''
+      # Skip when CODECOV_TOKEN is unavailable (fork PRs) and for any bot-authored PR.
+      if: always() && env.CODECOV_TOKEN != '' && github.event.pull_request.user.type != 'Bot'
       uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -186,8 +189,8 @@ jobs:
         verbose: false
 
     - name: Upload coverage to Codecov (processor)
-      # Skip when CODECOV_TOKEN is unavailable (fork/Dependabot PRs).
-      if: always() && env.CODECOV_TOKEN != ''
+      # Skip when CODECOV_TOKEN is unavailable (fork PRs) and for any bot-authored PR.
+      if: always() && env.CODECOV_TOKEN != '' && github.event.pull_request.user.type != 'Bot'
       uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Hardens the `Java CI with Maven` secret-bearing steps so they never run automatically for **bot-authored PRs**, using a generic account-type check instead of secret-emptiness or a hard-coded bot login.

Fixes #206

Before, the steps gated only on secret availability:

```yaml
if: env.SONAR_TOKEN != ''                 # Sonar
if: always() && env.CODECOV_TOKEN != ''   # Codecov
```

That is not robust: when a maintainer **re-runs** a Dependabot PR's jobs, secrets become available and the `SonarCloud Analysis` step executes (observed on #205: it ran and failed with `HTTP 403 ... check SONAR_TOKEN`). Matching `github.actor != 'dependabot[bot]'` is equally brittle — one exact name, misses other bots.

Now each secret step also requires the PR author to not be a bot:

```yaml
if: env.SONAR_TOKEN != '' && github.event.pull_request.user.type != 'Bot'
```

- `push` to `main`: no PR context → `user.type` is `''` → runs (unchanged).
- human same-repo PR: `user.type == 'User'` → runs.
- **any** bot PR (Dependabot, Renovate, …): `user.type == 'Bot'` → skipped, even on a maintainer re-run.
- fork PRs: unchanged — still covered by secret-withholding + the manual `fork-coverage`/`fork-sonar` workflows.

## Validation

- `actionlint` passes.
- Condition-only change; no build/test behaviour changes.