### PR TITLE
Add maintainer-run integration connectivity check workflow

### DIFF
--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -20,14 +20,6 @@ on:
           - all
           - sonarcloud
           - codecov
-      codecov_token_type:
-        description: 'What kind of secret CODECOV_TOKEN holds'
-        required: true
-        default: upload
-        type: choice
-        options:
-          - upload
-          - api
 
 permissions:
   contents: read
@@ -42,7 +34,6 @@ jobs:
     timeout-minutes: 10
     env:
       TARGET: ${{ github.event.inputs.target }}
-      CODECOV_TOKEN_TYPE: ${{ github.event.inputs.codecov_token_type }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -82,25 +73,16 @@ jobs:
           owner="${GITHUB_REPOSITORY%/*}"
           repo="${GITHUB_REPOSITORY#*/}"
           body="$RUNNER_TEMP/codecov.json"
-          if [ "$CODECOV_TOKEN_TYPE" = "api" ]; then
-            # API access token: read the repo detail via API v2. The token is
-            # sent only in the auth header; its value is never printed.
-            url="https://api.codecov.io/api/v2/github/$owner/repos/$repo/"
-            http_code="$(curl -sS -o "$body" -w '%{http_code}' \
-              -H "Authorization: bearer $CODECOV_TOKEN" "$url" || true)"
-            echo "GET api.codecov.io/api/v2/github/.../repos/... -> HTTP $http_code"
-          else
-            # Upload token: exercise the first step of Codecov's upload handshake
-            # (create-commit) against the real HEAD commit. This is the same call
-            # the uploader makes, so a valid token accepts it; the token is sent
-            # only in the auth header.
-            url="https://api.codecov.io/upload/github/$owner::::$repo/commits"
-            http_code="$(curl -sS -o "$body" -w '%{http_code}' -X POST \
-              -H "Authorization: token $CODECOV_TOKEN" \
-              -H 'Content-Type: application/json' \
-              -d "{\"commitid\":\"$GITHUB_SHA\"}" "$url" || true)"
-            echo "POST api.codecov.io/upload/github/.../commits -> HTTP $http_code"
-          fi
+          # CODECOV_TOKEN is the repo upload token: exercise the first step of
+          # Codecov's upload handshake (create-commit) against the real HEAD
+          # commit. This is the same call the uploader makes, so a valid token
+          # accepts it; the token is sent only in the auth header (never printed).
+          url="https://api.codecov.io/upload/github/$owner::::$repo/commits"
+          http_code="$(curl -sS -o "$body" -w '%{http_code}' -X POST \
+            -H "Authorization: token $CODECOV_TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d "{\"commitid\":\"$GITHUB_SHA\"}" "$url" || true)"
+          echo "POST api.codecov.io/upload/github/.../commits -> HTTP $http_code"
           case "$http_code" in
             200|201)
               echo "OK: CODECOV_TOKEN authenticates against Codecov." ;;

--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -90,7 +90,11 @@ jobs:
               echo "::error::Codecov rejected the token (HTTP $http_code) - it is invalid, expired, or lacks access to this repo."
               exit 1 ;;
             404)
-              echo "::error::Codecov returned 404 - the token authenticated but the repo is not set up on Codecov (or the token lacks visibility)."
+              # The upload endpoint returns 404 "Repository not found" both for an
+              # invalid/unauthorized upload token and for a repo not activated on
+              # Codecov (it does not disclose which, by design).
+              echo "::error::Codecov returned 404 'Repository not found' - the upload token is invalid/unauthorized, or the repo is not activated on Codecov."
+              cat "$body" || true
               exit 1 ;;
             *)
               echo "::error::Unexpected response from Codecov (HTTP $http_code) - likely a reachability/service issue."

--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -1,0 +1,80 @@
+name: 'Integration connectivity check'
+
+# Maintainer-only diagnostic: verify the 3rd-party integration secrets and their
+# endpoints are usable, without building or running any project/PR code.
+#
+# workflow_dispatch can only be started by users with write access, from the
+# default branch, so it is inherently maintainer-gated and never runs for fork
+# PRs. It performs authenticated HTTP checks only; token values are never
+# printed. This is a diagnostic and does not replace the fork-ci environment
+# approval that gates the actual Sonar publish.
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which integration(s) to check'
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - sonarcloud
+          - codecov
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integrations-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TARGET: ${{ github.event.inputs.target }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    steps:
+      - name: Check SonarCloud token and connectivity
+        if: env.TARGET == 'all' || env.TARGET == 'sonarcloud'
+        run: |
+          set -euo pipefail
+          if [ -z "${SONAR_TOKEN:-}" ]; then
+            echo "::error::SONAR_TOKEN secret is empty or not configured."
+            exit 1
+          fi
+          # Validate the token via SonarCloud's authentication endpoint. The token
+          # is sent as HTTP basic-auth username; its value is never printed.
+          http_code="$(curl -sS -o /tmp/sonar.json -w '%{http_code}' \
+            -u "$SONAR_TOKEN:" https://sonarcloud.io/api/authentication/validate || true)"
+          echo "sonarcloud.io/api/authentication/validate -> HTTP $http_code"
+          if [ "$http_code" != "200" ]; then
+            echo "::error::SonarCloud returned HTTP $http_code (token likely invalid/expired, or the API is unreachable)."
+            exit 1
+          fi
+          if ! grep -q '"valid":true' /tmp/sonar.json; then
+            echo "::error::SonarCloud reports the token as NOT valid."
+            cat /tmp/sonar.json
+            exit 1
+          fi
+          echo "OK: SONAR_TOKEN is valid and SonarCloud is reachable."
+
+      - name: Check Codecov token and connectivity
+        if: env.TARGET == 'all' || env.TARGET == 'codecov'
+        run: |
+          set -euo pipefail
+          if [ -z "${CODECOV_TOKEN:-}" ]; then
+            echo "::error::CODECOV_TOKEN secret is empty or not configured."
+            exit 1
+          fi
+          # Codecov upload tokens have no public "validate" endpoint, so this is a
+          # presence + reachability check against the Codecov API (stated honestly).
+          http_code="$(curl -sS -o /dev/null -w '%{http_code}' https://api.codecov.io/health || true)"
+          echo "api.codecov.io/health -> HTTP $http_code"
+          if [ "$http_code" != "200" ]; then
+            echo "::error::Codecov API not reachable (HTTP $http_code)."
+            exit 1
+          fi
+          echo "OK: CODECOV_TOKEN is present and the Codecov API is reachable (upload-token validity is not publicly verifiable)."

--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -20,6 +20,14 @@ on:
           - all
           - sonarcloud
           - codecov
+      codecov_token_type:
+        description: 'What kind of secret CODECOV_TOKEN holds'
+        required: true
+        default: upload
+        type: choice
+        options:
+          - upload
+          - api
 
 permissions:
   contents: read
@@ -34,6 +42,7 @@ jobs:
     timeout-minutes: 10
     env:
       TARGET: ${{ github.event.inputs.target }}
+      CODECOV_TOKEN_TYPE: ${{ github.event.inputs.codecov_token_type }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -70,18 +79,31 @@ jobs:
             echo "::error::CODECOV_TOKEN secret is empty or not configured."
             exit 1
           fi
-          # Exercise the token against a token-protected Codecov endpoint (the
-          # repo detail in API v2). A 200 means the token authenticates and can
-          # read this repo; 401/403 means the token is rejected; other codes are
-          # reachability/other errors. The token is sent only in the auth header.
-          body="$RUNNER_TEMP/codecov-repo.json"
-          url="https://api.codecov.io/api/v2/github/${GITHUB_REPOSITORY%/*}/repos/${GITHUB_REPOSITORY#*/}/"
-          http_code="$(curl -sS -o "$body" -w '%{http_code}' \
-            -H "Authorization: bearer $CODECOV_TOKEN" "$url" || true)"
-          echo "api.codecov.io/api/v2/github/.../repos/... -> HTTP $http_code"
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          body="$RUNNER_TEMP/codecov.json"
+          if [ "$CODECOV_TOKEN_TYPE" = "api" ]; then
+            # API access token: read the repo detail via API v2. The token is
+            # sent only in the auth header; its value is never printed.
+            url="https://api.codecov.io/api/v2/github/$owner/repos/$repo/"
+            http_code="$(curl -sS -o "$body" -w '%{http_code}' \
+              -H "Authorization: bearer $CODECOV_TOKEN" "$url" || true)"
+            echo "GET api.codecov.io/api/v2/github/.../repos/... -> HTTP $http_code"
+          else
+            # Upload token: exercise the first step of Codecov's upload handshake
+            # (create-commit) against the real HEAD commit. This is the same call
+            # the uploader makes, so a valid token accepts it; the token is sent
+            # only in the auth header.
+            url="https://api.codecov.io/upload/github/$owner::::$repo/commits"
+            http_code="$(curl -sS -o "$body" -w '%{http_code}' -X POST \
+              -H "Authorization: token $CODECOV_TOKEN" \
+              -H 'Content-Type: application/json' \
+              -d "{\"commitid\":\"$GITHUB_SHA\"}" "$url" || true)"
+            echo "POST api.codecov.io/upload/github/.../commits -> HTTP $http_code"
+          fi
           case "$http_code" in
-            200)
-              echo "OK: CODECOV_TOKEN authenticates and can read this repo on Codecov." ;;
+            200|201)
+              echo "OK: CODECOV_TOKEN authenticates against Codecov." ;;
             401|403)
               echo "::error::Codecov rejected the token (HTTP $http_code) - it is invalid, expired, or lacks access to this repo."
               exit 1 ;;

--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -47,16 +47,17 @@ jobs:
           fi
           # Validate the token via SonarCloud's authentication endpoint. The token
           # is sent as HTTP basic-auth username; its value is never printed.
-          http_code="$(curl -sS -o /tmp/sonar.json -w '%{http_code}' \
+          body="$RUNNER_TEMP/sonar-validate.json"
+          http_code="$(curl -sS -o "$body" -w '%{http_code}' \
             -u "$SONAR_TOKEN:" https://sonarcloud.io/api/authentication/validate || true)"
           echo "sonarcloud.io/api/authentication/validate -> HTTP $http_code"
           if [ "$http_code" != "200" ]; then
             echo "::error::SonarCloud returned HTTP $http_code (token likely invalid/expired, or the API is unreachable)."
             exit 1
           fi
-          if ! grep -q '"valid":true' /tmp/sonar.json; then
+          if ! grep -q '"valid":true' "$body"; then
             echo "::error::SonarCloud reports the token as NOT valid."
-            cat /tmp/sonar.json
+            cat "$body"
             exit 1
           fi
           echo "OK: SONAR_TOKEN is valid and SonarCloud is reachable."
@@ -69,12 +70,26 @@ jobs:
             echo "::error::CODECOV_TOKEN secret is empty or not configured."
             exit 1
           fi
-          # Codecov upload tokens have no public "validate" endpoint, so this is a
-          # presence + reachability check against the Codecov API (stated honestly).
-          http_code="$(curl -sS -o /dev/null -w '%{http_code}' https://api.codecov.io/health || true)"
-          echo "api.codecov.io/health -> HTTP $http_code"
-          if [ "$http_code" != "200" ]; then
-            echo "::error::Codecov API not reachable (HTTP $http_code)."
-            exit 1
-          fi
-          echo "OK: CODECOV_TOKEN is present and the Codecov API is reachable (upload-token validity is not publicly verifiable)."
+          # Exercise the token against a token-protected Codecov endpoint (the
+          # repo detail in API v2). A 200 means the token authenticates and can
+          # read this repo; 401/403 means the token is rejected; other codes are
+          # reachability/other errors. The token is sent only in the auth header.
+          body="$RUNNER_TEMP/codecov-repo.json"
+          url="https://api.codecov.io/api/v2/github/${GITHUB_REPOSITORY%/*}/repos/${GITHUB_REPOSITORY#*/}/"
+          http_code="$(curl -sS -o "$body" -w '%{http_code}' \
+            -H "Authorization: bearer $CODECOV_TOKEN" "$url" || true)"
+          echo "api.codecov.io/api/v2/github/.../repos/... -> HTTP $http_code"
+          case "$http_code" in
+            200)
+              echo "OK: CODECOV_TOKEN authenticates and can read this repo on Codecov." ;;
+            401|403)
+              echo "::error::Codecov rejected the token (HTTP $http_code) - it is invalid, expired, or lacks access to this repo."
+              exit 1 ;;
+            404)
+              echo "::error::Codecov returned 404 - the token authenticated but the repo is not set up on Codecov (or the token lacks visibility)."
+              exit 1 ;;
+            *)
+              echo "::error::Unexpected response from Codecov (HTTP $http_code) - likely a reachability/service issue."
+              cat "$body" || true
+              exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary

Adds `integrations-check.yml`, a **maintainer-only** `workflow_dispatch` diagnostic that verifies the 3rd-party integration secrets and endpoints in seconds — without building or running any project/PR code. Motivated by the fork Sonar publish failing with `HTTP 403 ... check SONAR_TOKEN`, where a full CI run was a slow/noisy way to discover a token problem.

`Fixes #208`

## Input

- `target`: `all` / `sonarcloud` / `codecov`.

## What it checks

- **SonarCloud** — `SONAR_TOKEN` present + **valid** via `GET https://sonarcloud.io/api/authentication/validate` (token as basic-auth username; value never printed). Fails on `403` / `"valid":false`.
- **Codecov** — `CODECOV_TOKEN` (the repo **upload** token) present + accepted by the first step of Codecov's upload handshake: `POST https://api.codecov.io/upload/github/<owner>::::<repo>/commits` with `Authorization: token …` against the real `GITHUB_SHA` (the same create-commit call the uploader makes).

Codecov result mapping: `200/201` = token authenticates; `401/403` = token rejected; `404` = authenticated but repo not set up / not visible; other = reachability/service issue. Temp files use `$RUNNER_TEMP`.

## Why it's safe

- `workflow_dispatch` is startable only by write-access users from the default branch → inherently maintainer-gated, never runs for fork PRs.
- No build, no PR-supplied code — only authenticated HTTP checks. Token values are never echoed (`set -euo pipefail`, tokens confined to env/auth header/basic-auth). The upload create-commit call targets the real HEAD commit, so it adds no spurious data.

## Scope

Single new workflow file; nothing else touched. Diagnostic only — does not replace the `fork-ci` environment approval that gates the actual Sonar publish.

## Maintainer TODOs

- [ ] After merge, run **Actions → Integration connectivity check → Run workflow** (only listable once on the default branch) to confirm `SONAR_TOKEN`/`CODECOV_TOKEN` — this should surface the current Sonar `403`.
