### PR TITLE
Run integration checks as parallel jobs and accept Codecov 202

### DIFF
--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -29,16 +29,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  # Independent jobs so the two checks run in parallel and a failing SonarCloud
+  # check never blocks the Codecov check (and vice versa).
+  sonarcloud:
+    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'sonarcloud' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      TARGET: ${{ github.event.inputs.target }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Check SonarCloud token and connectivity
-        if: env.TARGET == 'all' || env.TARGET == 'sonarcloud'
         run: |
           set -euo pipefail
           if [ -z "${SONAR_TOKEN:-}" ]; then
@@ -62,8 +62,14 @@ jobs:
           fi
           echo "OK: SONAR_TOKEN is valid and SonarCloud is reachable."
 
+  codecov:
+    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'codecov' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    steps:
       - name: Check Codecov token and connectivity
-        if: env.TARGET == 'all' || env.TARGET == 'codecov'
         run: |
           set -euo pipefail
           if [ -z "${CODECOV_TOKEN:-}" ]; then
@@ -84,8 +90,10 @@ jobs:
             -d "{\"commitid\":\"$GITHUB_SHA\"}" "$url" || true)"
           echo "POST api.codecov.io/upload/github/.../commits -> HTTP $http_code"
           case "$http_code" in
-            200|201)
-              echo "OK: CODECOV_TOKEN authenticates against Codecov." ;;
+            200|201|202)
+              # 202 "Accepted" means Codecov queued the create-commit request,
+              # which requires a valid, authorized token -> the token works.
+              echo "OK: CODECOV_TOKEN authenticates against Codecov (HTTP $http_code)." ;;
             401|403)
               echo "::error::Codecov rejected the token (HTTP $http_code) - it is invalid, expired, or lacks access to this repo."
               exit 1 ;;


### PR DESCRIPTION
## Summary

Follow-up to #209 (already merged), addressing what the first live run of the workflow revealed:

1. **Parallel, non-blocking checks** — the Sonar and Codecov checks were steps in one job, so a failing SonarCloud check aborted the job before the Codecov check ran. Split into two independent jobs (`sonarcloud`, `codecov`) that run in parallel, each gated by the `target` input.
2. **Codecov `202`** — the create-commit handshake is queued asynchronously and returns `202 Accepted`, not `200/201`. The check now treats `202` as success (a 202 still requires a valid, authorized upload token).

`Fixes #208`

## Maintainer TODOs

- [ ] Fix/rotate `SONAR_TOKEN` in SonarCloud (the run reported it invalid — same root cause as the earlier fork-Sonar `403`), then re-run **Actions → Integration connectivity check** to confirm both legs pass.
