### PR TITLE
Run integration connectivity check nightly to catch token expiry early (#208)

### DIFF
--- a/.github/workflows/integrations-check.yml
+++ b/.github/workflows/integrations-check.yml
@@ -8,6 +8,11 @@ name: 'Integration connectivity check'
 # PRs. It performs authenticated HTTP checks only; token values are never
 # printed. This is a diagnostic and does not replace the fork-ci environment
 # approval that gates the actual Sonar publish.
+#
+# It also runs on a nightly schedule so an expiring/revoked SONAR_TOKEN or
+# CODECOV_TOKEN surfaces as a failed run (and the usual GitHub failure
+# notification) before it silently breaks a real CI/release run. Scheduled runs
+# check all integrations.
 on:
   workflow_dispatch:
     inputs:
@@ -20,6 +25,9 @@ on:
           - all
           - sonarcloud
           - codecov
+  schedule:
+    # Nightly at 06:00 UTC. Scheduled runs only execute from the default branch.
+    - cron: '0 6 * * *'
 
 permissions:
   contents: read
@@ -32,7 +40,8 @@ jobs:
   # Independent jobs so the two checks run in parallel and a failing SonarCloud
   # check never blocks the Codecov check (and vice versa).
   sonarcloud:
-    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'sonarcloud' }}
+    # Scheduled runs have no dispatch inputs, so always run both checks then.
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'sonarcloud' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -63,7 +72,8 @@ jobs:
           echo "OK: SONAR_TOKEN is valid and SonarCloud is reachable."
 
   codecov:
-    if: ${{ github.event.inputs.target == 'all' || github.event.inputs.target == 'codecov' }}
+    # Scheduled runs have no dispatch inputs, so always run both checks then.
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'codecov' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## Summary

Adds a nightly `schedule` trigger to the existing `integrations-check.yml` so that an expiring/revoked `SONAR_TOKEN` or `CODECOV_TOKEN` surfaces as a failed scheduled run (with GitHub's normal failure notification to maintainers) **before** it silently breaks a real CI or release run. Requested in #208.

The workflow already runs the SonarCloud and Codecov token/connectivity checks as two independent, parallel jobs on manual `workflow_dispatch`. This PR only adds the schedule and makes the job gates schedule-aware:

```yaml
on:
  workflow_dispatch: { inputs: { target: [all|sonarcloud|codecov] } }
  schedule:
    - cron: '0 6 * * *'   # nightly 06:00 UTC, default branch only

jobs:
  sonarcloud:
    # dispatch has a target input; scheduled runs have none -> run both checks
    if: ${{ github.event_name == 'schedule' || inputs.target == 'all' || inputs.target == 'sonarcloud' }}
  codecov:
    if: ${{ github.event_name == 'schedule' || inputs.target == 'all' || inputs.target == 'codecov' }}
```

Scheduled runs carry no dispatch `inputs`, so without the `github.event_name == 'schedule'` clause both jobs' `if` conditions would evaluate false and be skipped — hence the added clause runs **all** checks on the nightly run. No check logic changed; token values are still never printed and no project/PR code is built. `schedule` (like `workflow_dispatch`) only executes from the default branch, so this remains maintainer-gated and never runs for fork PRs.

## Related
- #208 (integration connectivity check)

Note: `SONAR_TOKEN` is currently reported invalid by this check — that token still needs to be fixed/rotated in SonarCloud (tracked in #208); once fixed, the nightly run will go green.
