### PR TITLE
Submit Maven dependency snapshots; drop counterproductive dependency-review retry

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -50,9 +50,11 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
+          # Fork PR head SHAs may show "No snapshots were found for the head SHA" because
+          # submitting a snapshot would require building untrusted fork code with a write
+          # token. This is expected and benign: the check uses the manifest-derived graph
+          # and still passes. dependency-submission.yml provides snapshots for main.
           # Fail the PR when it introduces a vulnerability at or above this severity.
           fail-on-severity: high
           # Block copyleft / incompatible licenses that conflict with this MIT project.
           deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later, AGPL-3.0-or-later
-          # Snapshot dependency data can lag right after a push; retry instead of failing spuriously.
-          retry-on-snapshot-warnings: true

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,34 @@
+# Submit the full transitive Maven dependency snapshot to the repository's dependency graph.
+# This improves vulnerability detection beyond static manifest parsing and provides snapshots
+# for main so dependency review has real snapshot data to compare against.
+name: Dependency submission
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Cancel superseded runs for the same ref to save runner minutes.
+concurrency:
+  group: dependency-submission-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: maven
+
+      - name: Submit Maven dependency snapshot
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0


### PR DESCRIPTION
## Summary

Fixes the confusing **"No snapshots were found for the head SHA"** warning that `dependency-review` posts in PR comments. The check is *not* actually failing — it's green — but the warning is prominent and looks like a failure. Fixes #212 (follow-up to #160 / #182).

**Root cause:** this Maven repo's dependency graph is populated only by GitHub's static `pom.xml` parsing. No dependency *submission* snapshots exist, so `dependency-review-action` emits the snapshot warning while still passing via the manifest-derived graph. The `retry-on-snapshot-warnings: true` added in #182 is counterproductive here — with no submission workflow it retries ~2 min for a snapshot that never arrives, then proceeds with the warning anyway.

**Changes:**

1. New `dependency-submission.yml` — on push to `main` (+ manual dispatch), submits the full **transitive** Maven dependency snapshot to the dependency graph via `advanced-security/maven-dependency-submission-action` (SHA-pinned `@v5.0.0`, `contents: write`). This improves vulnerability coverage (transitive, not just declared deps) and gives `main` real snapshot data for reviews to compare against.

2. `dependency-review.yml` — remove the counterproductive `retry-on-snapshot-warnings`, and document that the head-SHA warning on **fork** PRs is expected/benign:

```diff
   comment-summary-in-pr: always
+  # Fork PR head SHAs may show "No snapshots were found for the head SHA" because
+  # submitting a snapshot would require building untrusted fork code with a write
+  # token. Expected & benign: the check uses the manifest-derived graph and passes.
   fail-on-severity: high
   deny-licenses: GPL-1.0-or-later, ...
-  # Snapshot dependency data can lag right after a push; retry instead of failing spuriously.
-  retry-on-snapshot-warnings: true
```

**Why the head-SHA warning can't be fully removed for fork PRs:** submitting a snapshot for a fork PR's head commit would require building untrusted fork code with a `contents: write` token — the exact pattern the fork-CI design deliberately avoids. So the base side (`main`) gets snapshots; the fork PR head warning remains but is harmless and now documented.

## Related
- #212 (this issue), #160 / #182 (original dependency-review work)
