### PR TITLE
Stop dependency-review from commenting the benign fork-PR snapshot warning

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -49,10 +49,17 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
-          comment-summary-in-pr: always
+          # Only post/refresh the PR summary comment when the review actually
+          # fails (a vulnerability or denied license). This avoids spamming
+          # every PR with a comment whose only content is the benign
+          # "No snapshots were found for the head SHA" warning: for fork PRs
+          # GitHub has only the manifest-derived dependency graph (no submitted
+          # snapshot for the fork head, and one can't be produced without
+          # building untrusted fork code with a write token). The check still
+          # runs and still fails on real issues; the warning is only visible in
+          # the Actions run log.
+          comment-summary-in-pr: on-failure
           # Fail the PR when it introduces a vulnerability at or above this severity.
           fail-on-severity: high
           # Block copyleft / incompatible licenses that conflict with this MIT project.
           deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later, AGPL-3.0-or-later
-          # Snapshot dependency data can lag right after a push; retry instead of failing spuriously.
-          retry-on-snapshot-warnings: true


### PR DESCRIPTION
## Summary

Stops the `dependency-review` check from posting the confusing **"No snapshots were found for the head SHA"** warning as a comment on every PR. Fixes #212 (follow-up to #160 / #182).

**Root cause / why the earlier idea doesn't work:** the warning is *not* a failure — the check is green. It appears because for a fork PR head GitHub has only the *manifest-derived* dependency graph and no *submitted* snapshot. A submitted snapshot can't be produced for a fork PR head without building untrusted fork code with a write token (the pattern the fork-CI design deliberately avoids), and submitting on `main` doesn't help a PR head. So the warning can't be "fixed" by adding data — it has to be configured away.

**Fix:** switch `comment-summary-in-pr` from `always` to `on-failure`. The action only creates/updates the PR summary comment when the review actually fails (a vulnerability at/above `fail-on-severity`, or a denied license); snapshot warnings alone never trigger a comment. On clean PRs there is now no comment, so the benign snapshot warning stops showing up on PRs. The warning remains only in the Actions run log, and the check still runs and still fails on real issues.

```diff
   with:
-    comment-summary-in-pr: always
+    comment-summary-in-pr: on-failure   # only comment when there's a real vuln/license failure
     fail-on-severity: high
     deny-licenses: GPL-1.0-or-later, ...
-    # Snapshot dependency data can lag right after a push; retry instead of failing spuriously.
-    retry-on-snapshot-warnings: true    # counterproductive here: no submission exists, so it just wastes ~2 min
```

This is the standard approach for OSS projects (GitHub's own starter workflow defaults `comment-summary-in-pr` to `never`; `on-failure` keeps a helpful comment when it matters). Tradeoff: no "✅ No vulnerabilities" comment on clean PRs — the green check conveys that instead.

Also removes `retry-on-snapshot-warnings: true` (added in #182): with no submission workflow it just retries ~2 min for a snapshot that never arrives, then proceeds with the warning anyway.

## Related
- #212, #160 / #182

## Note
A separate, optional enhancement (not in this PR) would be adding a Maven dependency **submission** workflow on `main` for fuller *transitive* dependency coverage in the graph/Dependabot alerts — but that is orthogonal to this warning and I left it out to keep this focused. Happy to add it if you want it.
