### PR TITLE
Migrate dependency-review to allow-licenses (deny-licenses deprecated)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -56,5 +56,6 @@ jobs:
           # and still passes. dependency-submission.yml provides snapshots for main.
           # Fail the PR when it introduces a vulnerability at or above this severity.
           fail-on-severity: high
-          # Block copyleft / incompatible licenses that conflict with this MIT project.
-          deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later, AGPL-3.0-or-later
+          # Fail closed with licenses derived from the project's full dependency tree,
+          # replacing the deprecated deny-licenses option.
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, EPL-1.0, EPL-2.0, CDDL-1.0, CDDL-1.1, ISC, Unlicense, CC0-1.0


### PR DESCRIPTION
## Summary

Migrates `dependency-review.yml` off the **deprecated `deny-licenses`** option (the action now warns it may be removed in the next major release — actions/dependency-review-action#938) to the supported **`allow-licenses`** allow-list. Reopens/addresses #160.

```diff
-          # Block copyleft / incompatible licenses that conflict with this MIT project.
-          deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later, AGPL-3.0-or-later
+          # Fail closed with licenses derived from the project's full dependency tree,
+          # replacing the deprecated deny-licenses option.
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, EPL-1.0, EPL-2.0, CDDL-1.0, CDDL-1.1, ISC, Unlicense, CC0-1.0
```

## Semantic change (please note)

`allow-licenses` and `deny-licenses` are mutually exclusive and behave oppositely:

- **`deny-licenses` (before):** fail-open — only *detected* copyleft (GPL/LGPL/AGPL) fails; a dependency with an unrecognized/`OTHER` license is reported but **passes**.
- **`allow-licenses` (after):** fail-closed — any introduced dependency whose license is **not** on the list fails, including unrecognized/`OTHER` ones.

Fail-closed is the stronger posture and matches the deprecation's recommended direction, but it can surface false failures when ClearlyDefined can't identify a license. If that happens, either add the specific SPDX id or exempt the package via `allow-dependencies-licenses`.

## How the list was derived

Enumerated the full dependency tree across all modules (core, processor, example, example-custom-generator) via `license-maven-plugin:aggregate-third-party-report` (35 deps, all with declared licenses). Distinct licenses found → SPDX:

| Found | SPDX |
|---|---|
| Apache License 2.0 (several spellings) | `Apache-2.0` |
| MIT / The MIT License | `MIT` |
| Eclipse Public License 1.0 | `EPL-1.0` |
| Eclipse Public License v2.0 | `EPL-2.0` |
| New BSD License / BSD-3-Clause | `BSD-3-Clause` |

No GPL/LGPL/AGPL present. The allow-list adds the standard permissive set for a Java/MIT project (BSD-2-Clause, CDDL-1.0/1.1, ISC, Unlicense, CC0-1.0) as headroom for common transitive deps.

## Note
Touches the same block as #216 (which flips `comment-summary-in-pr` to `on-failure`), so a trivial conflict is expected on whichever merges second — easily resolved (they change adjacent, unrelated lines).

## Related
- Fixes #160
