### PR TITLE
[DO NOT MERGE] Test: dependency-review gates should fail on GPL + vulnerable deps

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -57,6 +57,20 @@
       <version>${jackson-databind.version}</version>
     </dependency>
 
+    <!-- DO NOT MERGE: intentionally added to exercise the dependency-review gates. -->
+    <!-- GPL-2.0 licensed -> should trip the license gate. -->
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>9.1.0</version>
+    </dependency>
+    <!-- Log4Shell (CVE-2021-44228, critical) -> should trip the severity gate. -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+
   </dependencies>
 
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — dependency-review gate test

This PR deliberately introduces two bad dependencies in `example/pom.xml` to prove the `dependency-review` gates actually fire. It is a **draft** and must **not** be merged.

| Dependency | Why it should fail |
|---|---|
| `com.mysql:mysql-connector-j:9.1.0` | **GPL-2.0** licensed → trips the **license gate** (`deny-licenses` on `main`; `allow-licenses` once #218 merges). |
| `org.apache.logging.log4j:log4j-core:2.14.1` | **Log4Shell** (CVE-2021-44228, critical) → trips the **severity gate** (`fail-on-severity: high`). |

### Expected result
The `dependency-review` check turns this PR **red**, reporting the denied license and the critical vulnerability. That is the pass condition for this experiment.

After you've confirmed the check goes red, this PR should be **closed** (not merged). Fork PRs need a maintainer "Approve and run" click before the check executes.
