### PR TITLE
Docs: how peer builder features are already solved the Simple Builders way

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ For non-nullable constructor fields, `build()` requires the builder value to be 
 For non-nullable setter fields, the field remains optional, but a value supplied to the builder must
 be non-null. Violations throw `IllegalStateException`.
 
-For example, the primitive `price` below is required and cannot be null:
+For example, both the primitive `price` and the `@NotNull` `name` below are required — omitting
+either makes `build()` fail:
 
 ```java
 @SimpleBuilder
@@ -211,6 +212,10 @@ public record Product(@NotNull String name, double price) {}
 ProductBuilder.create()
     .name("Keyboard")
     .build(); // throws IllegalStateException: price must be set
+
+ProductBuilder.create()
+    .price(99.0)
+    .build(); // throws IllegalStateException: name must be set
 ```
 
 The `NotNull`/`NonNull` simple-name check is framework-agnostic; use the annotation type already

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Use Simple Builders when you want fluent, type-safe builders for the classes and
 - **Copy / `with` / `toBuilder`:** The generated `With` interface provides `instance.with(b -> ...)` for copy-and-modify and `instance.with()` for a builder pre-populated from the instance ([`generateWithInterface`](docs/CONFIGURATION.md#generatewithinterface)).
 - **Collection immutability:** The target type owns the collection contract. Simple Builders passes through what the type stores; use defensive copying such as `List.copyOf(...)` in the type when the result must be immutable ([configuration details](#collection-immutability)).
 - **Incremental / singular collection API:** `add2X` helpers, `ArrayList`/`HashSet`/`HashMap` collection builders, and varargs helpers cover incremental collection construction ([collection helper options](docs/CONFIGURATION.md#collection-helpers)).
-- **Default values:** Classes can use field initializers; records can establish defaults in their canonical or compact constructor, or behind a static factory ([configuration options](docs/CONFIGURATION.md#configuration-options)).
 - **Inheritance:** Inherited setters are discovered, and constructors exposed by the annotated subclass are used. A final superclass field not exposed by that constructor is intentionally not bypassed ([configuration options](docs/CONFIGURATION.md#configuration-options)).
 
 Value semantics (`equals`, `hashCode`, `toString`) and generating brand-new immutable value types are deliberate out-of-scope paradigm choices, not missing builder features.
@@ -212,11 +211,6 @@ public record Product(@NotNull String name, double price) {}
 ProductBuilder.create()
     .name("Keyboard")
     .build(); // throws IllegalStateException: price must be set
-
-ProductBuilder.create()
-    .name(null)
-    .price(99.0)
-    .build(); // throws IllegalStateException: name cannot be null
 ```
 
 The `NotNull`/`NonNull` simple-name check is framework-agnostic; use the annotation type already

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ A zero-reflection Java annotation processor that generates fluent, type-safe bui
 - [Usage](#usage)
   - [Basic Usage](#basic-usage)
     - [Validation Annotations](#validation-annotations)
+    - [Required Fields and Null-Safety](#required-fields-and-null-safety)
     - [Conditional Builder Logic](#conditional-builder-logic)
   - [Collections and Nested Objects](#collections-and-nested-objects)
+    - [Collection Immutability](#collection-immutability)
   - [With Interface Pattern](#with-interface-pattern)
   - [Builder Configuration](#builder-configuration)
     - [Compiler Arguments](#compiler-arguments)
@@ -50,9 +52,9 @@ Use Simple Builders when you want fluent, type-safe builders for the classes and
 
 ### Doing what other builders advertise — the Simple Builders way
 
-- **Required fields:** Primitive fields and fields annotated with an annotation named `NotNull` or `NonNull` are non-nullable; constructor parameters are builder inputs. `build()` enforces the required/non-null contract with `IllegalStateException` ([configuration details](docs/CONFIGURATION.md#required-fields-and-null-safety)).
+- **Required fields:** Primitive fields and fields annotated with an annotation named `NotNull` or `NonNull` are non-nullable; constructor parameters are builder inputs. `build()` enforces the required/non-null contract with `IllegalStateException` ([configuration details](#required-fields-and-null-safety)).
 - **Copy / `with` / `toBuilder`:** The generated `With` interface provides `instance.with(b -> ...)` for copy-and-modify and `instance.with()` for a builder pre-populated from the instance ([`generateWithInterface`](docs/CONFIGURATION.md#generatewithinterface)).
-- **Collection immutability:** The target type owns the collection contract. Simple Builders passes through what the type stores; use defensive copying such as `List.copyOf(...)` in the type when the result must be immutable ([configuration details](docs/CONFIGURATION.md#collection-immutability)).
+- **Collection immutability:** The target type owns the collection contract. Simple Builders passes through what the type stores; use defensive copying such as `List.copyOf(...)` in the type when the result must be immutable ([configuration details](#collection-immutability)).
 - **Incremental / singular collection API:** `add2X` helpers, `ArrayList`/`HashSet`/`HashMap` collection builders, and varargs helpers cover incremental collection construction ([collection helper options](docs/CONFIGURATION.md#collection-helpers)).
 - **Default values:** Classes can use field initializers; records can establish defaults in their canonical or compact constructor, or behind a static factory ([configuration options](docs/CONFIGURATION.md#configuration-options)).
 - **Inheritance:** Inherited setters are discovered, and constructors exposed by the annotated subclass are used. A final superclass field not exposed by that constructor is intentionally not bypassed ([configuration options](docs/CONFIGURATION.md#configuration-options)).
@@ -191,6 +193,35 @@ User user = UserBuilder.create()
 
 This ensures validation frameworks work seamlessly with builder-generated objects.
 
+#### Required Fields and Null-Safety
+
+Simple Builders treats a field as non-nullable when its type is primitive or its parameter carries
+an annotation whose simple name is `NotNull` or `NonNull`, regardless of the annotation package.
+The name is matched without requiring a particular validation framework.
+
+For non-nullable constructor fields, `build()` requires the builder value to be set and non-null.
+For non-nullable setter fields, the field remains optional, but a value supplied to the builder must
+be non-null. Violations throw `IllegalStateException`.
+
+For example, the primitive `price` below is required and cannot be null:
+
+```java
+@SimpleBuilder
+public record Product(@NotNull String name, double price) {}
+
+ProductBuilder.create()
+    .name("Keyboard")
+    .build(); // throws IllegalStateException: price must be set
+
+ProductBuilder.create()
+    .name(null)
+    .price(99.0)
+    .build(); // throws IllegalStateException: name cannot be null
+```
+
+The `NotNull`/`NonNull` simple-name check is framework-agnostic; use the annotation type already
+used by your project.
+
 #### Conditional Builder Logic
 
 Apply builder modifications conditionally using the `conditional()` method:
@@ -266,6 +297,25 @@ Project project = ProjectBuilder.create()
         .put("owner", "dev-team"))
     .build();
 ```
+
+#### Collection Immutability
+
+Immutability of collections in the built object is the target type's responsibility. Simple
+Builders stores exactly what the target type stores and does not silently wrap collections, so the
+target type's collection contract remains intact. For a record, enforce that contract in its
+canonical or compact constructor:
+
+```java
+@SimpleBuilder
+public record Basket(List<String> items) {
+    public Basket {
+        items = List.copyOf(items);
+    }
+}
+```
+
+The builder passes its collection value to `Basket`; the record makes the stored collection
+unmodifiable.
 
 
 ### With Interface Pattern

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A zero-reflection Java annotation processor that generates fluent, type-safe bui
 ## Table of Contents
 - [What is Simple Builders?](#what-is-simple-builders)
 - [How Simple Builders compares](#how-simple-builders-compares)
+  - [Doing what other builders advertise — the Simple Builders way](#doing-what-other-builders-advertise-the-simple-builders-way)
 - [Features](#features)
 - [Requirements](#requirements)
 - [Installation](#installation)
@@ -46,6 +47,17 @@ Simple Builders generates fluent, type-safe builders for your **existing** class
 - **RecordBuilder** — focused, excellent builders and `with` methods for records. Choose it if you use records exclusively.
 
 Use Simple Builders when you want fluent, type-safe builders for the classes and records you already have, generated as plain readable source, with no bytecode manipulation and no IDE plugin — and no lock-in: because the builders are ordinary generated Java, you can drop the dependency at any time by copying the generated builder classes into your own sources, and they keep working.
+
+### Doing what other builders advertise — the Simple Builders way
+
+- **Required fields:** Primitive fields and fields annotated with an annotation named `NotNull` or `NonNull` are non-nullable; constructor parameters are builder inputs. `build()` enforces the required/non-null contract with `IllegalStateException` ([configuration details](docs/CONFIGURATION.md#required-fields-and-null-safety)).
+- **Copy / `with` / `toBuilder`:** The generated `With` interface provides `instance.with(b -> ...)` for copy-and-modify and `instance.with()` for a builder pre-populated from the instance ([`generateWithInterface`](docs/CONFIGURATION.md#generatewithinterface)).
+- **Collection immutability:** The target type owns the collection contract. Simple Builders passes through what the type stores; use defensive copying such as `List.copyOf(...)` in the type when the result must be immutable ([configuration details](docs/CONFIGURATION.md#collection-immutability)).
+- **Incremental / singular collection API:** `add2X` helpers, `ArrayList`/`HashSet`/`HashMap` collection builders, and varargs helpers cover incremental collection construction ([collection helper options](docs/CONFIGURATION.md#collection-helpers)).
+- **Default values:** Classes can use field initializers; records can establish defaults in their canonical or compact constructor, or behind a static factory ([configuration options](docs/CONFIGURATION.md#configuration-options)).
+- **Inheritance:** Inherited setters are discovered, and constructors exposed by the annotated subclass are used. A final superclass field not exposed by that constructor is intentionally not bypassed ([configuration options](docs/CONFIGURATION.md#configuration-options)).
+
+Value semantics (`equals`, `hashCode`, `toString`) and generating brand-new immutable value types are deliberate out-of-scope paradigm choices, not missing builder features.
 
 ## Features
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,7 +15,9 @@ Simple-builders supports fine-grained configuration through the `@SimpleBuilder.
   - [Field Setter Generation](#field-setter-generation)
   - [Conditional Logic](#conditional-logic)
   - [Access Control](#access-control)
+  - [Required Fields and Null-Safety](#required-fields-and-null-safety)
   - [Collection Helpers](#collection-helpers)
+    - [Collection Immutability](#collection-immutability)
   - [Component Filtering](#component-filtering)
   - [Integration](#integration)
   - [Reliability](#reliability)
@@ -498,6 +500,38 @@ public Builder items(List<@NotNull String> items) { ... }
 
 ---
 
+### Required Fields and Null-Safety
+
+Simple Builders treats constructor parameters as inputs to the selected target constructor. A field
+is non-nullable when its type is primitive or its parameter carries an annotation whose simple name
+is `NotNull` or `NonNull`, regardless of the annotation package. The annotation name is matched
+without requiring a particular validation framework.
+
+For non-nullable constructor fields, `build()` requires the builder value to be set and non-null.
+For non-nullable setter fields, the field remains optional, but a value supplied to the builder must
+be non-null. Violations throw `IllegalStateException`.
+
+For example, the primitive `price` below is required and cannot be null:
+
+```java
+@SimpleBuilder
+public record Product(@NotNull String name, double price) {}
+
+ProductBuilder.create()
+    .name("Keyboard")
+    .build(); // throws IllegalStateException: price must be set
+
+ProductBuilder.create()
+    .name(null)
+    .price(99.0)
+    .build(); // throws IllegalStateException: name cannot be null
+```
+
+The `NotNull`/`NonNull` simple-name check is framework-agnostic; use the annotation type already
+used by your project.
+
+---
+
 ### Collection Helpers
 
 #### `usingArrayListBuilder`
@@ -605,6 +639,27 @@ public TeamDtoBuilder uniqueMembers(Consumer<HashSetBuilderWithElementBuilders<P
 **Default**: `ENABLED` | **Compiler Option**: `-Asimplebuilder.usingHashMapBuilder=ENABLED|DISABLED`
 
 Generates methods using `HashMapBuilder` for fluent Map construction.
+
+---
+
+#### Collection Immutability
+
+Immutability of collections in the built object is the target type's responsibility. Simple
+Builders stores exactly what the target type stores and does not silently wrap collections, so the
+target type's collection contract remains intact. For a record, enforce that contract in its
+canonical or compact constructor:
+
+```java
+@SimpleBuilder
+public record Basket(List<String> items) {
+    public Basket {
+        items = List.copyOf(items);
+    }
+}
+```
+
+The builder passes its collection value to `Basket`; the record makes the stored collection
+unmodifiable.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,9 +15,7 @@ Simple-builders supports fine-grained configuration through the `@SimpleBuilder.
   - [Field Setter Generation](#field-setter-generation)
   - [Conditional Logic](#conditional-logic)
   - [Access Control](#access-control)
-  - [Required Fields and Null-Safety](#required-fields-and-null-safety)
   - [Collection Helpers](#collection-helpers)
-    - [Collection Immutability](#collection-immutability)
   - [Component Filtering](#component-filtering)
   - [Integration](#integration)
   - [Reliability](#reliability)
@@ -500,38 +498,6 @@ public Builder items(List<@NotNull String> items) { ... }
 
 ---
 
-### Required Fields and Null-Safety
-
-Simple Builders treats constructor parameters as inputs to the selected target constructor. A field
-is non-nullable when its type is primitive or its parameter carries an annotation whose simple name
-is `NotNull` or `NonNull`, regardless of the annotation package. The annotation name is matched
-without requiring a particular validation framework.
-
-For non-nullable constructor fields, `build()` requires the builder value to be set and non-null.
-For non-nullable setter fields, the field remains optional, but a value supplied to the builder must
-be non-null. Violations throw `IllegalStateException`.
-
-For example, the primitive `price` below is required and cannot be null:
-
-```java
-@SimpleBuilder
-public record Product(@NotNull String name, double price) {}
-
-ProductBuilder.create()
-    .name("Keyboard")
-    .build(); // throws IllegalStateException: price must be set
-
-ProductBuilder.create()
-    .name(null)
-    .price(99.0)
-    .build(); // throws IllegalStateException: name cannot be null
-```
-
-The `NotNull`/`NonNull` simple-name check is framework-agnostic; use the annotation type already
-used by your project.
-
----
-
 ### Collection Helpers
 
 #### `usingArrayListBuilder`
@@ -639,27 +605,6 @@ public TeamDtoBuilder uniqueMembers(Consumer<HashSetBuilderWithElementBuilders<P
 **Default**: `ENABLED` | **Compiler Option**: `-Asimplebuilder.usingHashMapBuilder=ENABLED|DISABLED`
 
 Generates methods using `HashMapBuilder` for fluent Map construction.
-
----
-
-#### Collection Immutability
-
-Immutability of collections in the built object is the target type's responsibility. Simple
-Builders stores exactly what the target type stores and does not silently wrap collections, so the
-target type's collection contract remains intact. For a record, enforce that contract in its
-canonical or compact constructor:
-
-```java
-@SimpleBuilder
-public record Basket(List<String> items) {
-    public Basket {
-        items = List.copyOf(items);
-    }
-}
-```
-
-The builder passes its collection value to `Basket`; the record makes the stored collection
-unmodifiable.
 
 ---
 


### PR DESCRIPTION
## Documentation: how peer builder features are already solved the Simple Builders way

Closes #225.

### Why
A feature comparison against Lombok, Immutables, AutoValue, FreeBuilder and RecordBuilder found that several capabilities those libraries advertise are **already supported** by Simple Builders — but implemented in an SB-specific way that follows its design paradigm (*augment the types you already have; never redefine their semantics*). Because the "SB way" of each wasn't documented, a fresh comparison (human or AI) mistakes them for missing features. This PR is **documentation only** — no source or behavior changes — so those "gaps" aren't re-raised.

### What changed (README only)

**"How Simple Builders compares" → new subsection** *"Doing what other builders advertise — the Simple Builders way"*, with one concise entry per capability, each linking to the relevant Usage section:
- Required fields / null-safety
- Copy / `with` / `toBuilder` (the `With` interface)
- Collection immutability (the target type's responsibility)
- Incremental / "singular" collection API (`add2X`, collection builders, varargs)
- Inheritance (inherited setters + subclass-constructor-exposed fields)

(Default values are intentionally **not** listed — SB has no first-class default mechanism; that missing feature is tracked in #227.)

Plus an explicit note that generating value semantics (`equals`/`hashCode`/`toString`) and brand-new immutable value types are deliberate out-of-scope paradigm choices, not missing features.

**Usage section — two new subsections documenting inherent behavior** (placed here, not in CONFIGURATION.md, because these are behaviors, not configurable options):
- **Required Fields and Null-Safety** (after *Validation Annotations*) — a field is non-nullable when its type is primitive or it carries a `NotNull`/`NonNull`-named annotation (any package, matched by simple name). `build()` then enforces: constructor fields must be set and non-null; setter fields, if set, must be non-null — violations throw `IllegalStateException`. Includes a record example.
- **Collection Immutability** (end of *Collections and Nested Objects*) — immutability of built collections is the target type's responsibility; SB stores exactly what the type stores and never silently wraps collections. Includes a record compact-constructor `List.copyOf(...)` example.

TOC updated for all three new subsections. `docs/CONFIGURATION.md` is unchanged.

### Verification
- `git diff --check` clean
- `mvn -N validate` passes
- All new internal anchors resolve against actual headings
