### PR TITLE
Fix Sonar S2259 potential NPEs to restore reliability rating (#231)

### DIFF
--- a/processor/src/main/java/org/javahelpers/simple/builders/processor/analysis/JavaLangMapper.java
+++ b/processor/src/main/java/org/javahelpers/simple/builders/processor/analysis/JavaLangMapper.java
@@ -693,7 +693,8 @@ public final class JavaLangMapper {
    * @return true if it's a concrete class
    */
   private static boolean isConcreteClass(TypeElement typeElement) {
-    return typeElement.getKind() == javax.lang.model.element.ElementKind.CLASS
+    return typeElement != null
+        && typeElement.getKind() == javax.lang.model.element.ElementKind.CLASS
         && !typeElement.getModifiers().contains(javax.lang.model.element.Modifier.ABSTRACT);
   }
 }

--- a/processor/src/main/java/org/javahelpers/simple/builders/processor/util/ImportCollector.java
+++ b/processor/src/main/java/org/javahelpers/simple/builders/processor/util/ImportCollector.java
@@ -2,6 +2,7 @@ package org.javahelpers.simple.builders.processor.util;
 
 import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -15,6 +16,7 @@ import org.javahelpers.simple.builders.processor.model.method.MethodCodePlacehol
 import org.javahelpers.simple.builders.processor.model.method.MethodCodeTypePlaceholder;
 import org.javahelpers.simple.builders.processor.model.method.MethodDto;
 import org.javahelpers.simple.builders.processor.model.method.MethodParameterDto;
+import org.javahelpers.simple.builders.processor.model.type.GenericParameterDto;
 import org.javahelpers.simple.builders.processor.model.type.TypeName;
 import org.javahelpers.simple.builders.processor.model.type.TypeNameArray;
 import org.javahelpers.simple.builders.processor.model.type.TypeNameGeneric;
@@ -147,9 +149,10 @@ public class ImportCollector {
 
     // Add class type and generics
     addTypeImports(classDef.getTypeName());
-    classDef
-        .getGenerics()
-        .forEach(generic -> generic.getUpperBounds().forEach(this::addTypeImports));
+    List<GenericParameterDto> generics = classDef.getGenerics();
+    if (generics != null) {
+      generics.forEach(generic -> generic.getUpperBounds().forEach(this::addTypeImports));
+    }
 
     // Add interface imports
     classDef.getInterfaces().forEach(this::addInterfaceImports);


### PR DESCRIPTION
## Summary

Fixes the two `javabugs:S2259` ("access that may throw a `NullPointerException`") findings that push the SonarCloud **new-code Reliability rating on `main` to C** and fail the quality gate. Restores the reliability rating to **A**.

Fixes #231.

## Changes

**`JavaLangMapper.isConcreteClass`** — real missing null-guard. Sonar's interprocedural flow (`map` → `setEmptyConstructorInfoIfAvailable` → `isConcreteClass`) shows `typeElement` may be `null`, so `typeElement.getKind()` could NPE. Guarded the parameter:

```java
return typeElement != null
    && typeElement.getKind() == ElementKind.CLASS
    && !typeElement.getModifiers().contains(Modifier.ABSTRACT);
```

**`ImportCollector.collectImports`** — defensive guard for a Sonar dataflow false positive. `GenerationTargetClassDto.generics` is a `final` field initialised to `new LinkedList<>()` with no setter, so `getGenerics()` is never `null`; Sonar cannot prove that across the mapper. Assigned to a local and guarded:

```java
List<GenericParameterDto> generics = classDef.getGenerics();
if (generics != null) {
  generics.forEach(generic -> generic.getUpperBounds().forEach(this::addTypeImports));
}
```

No behavior change.

## Verification
- `mvn -B install -Pmetrics --file pom.xml` → BUILD SUCCESS, 311 processor tests pass (0 failures/errors), google-java-format clean.
- Generated-source gate clean: after `rm -rf example/generated-example-builder && mvn -B -q -DskipTests -pl example clean compile`, `git status --porcelain -- example/generated-example-builder` is empty.

## Out of scope (tracked separately)
- `githubactions:S7631` on `fork-sonar.yml` — security rating (analysis task #232).
- New-code duplication — accepted; to be resolved by extracting the shared model into its own project (#233).
