### PR TITLE
Rename release pipeline commit messages and PR title from chore to release

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -123,7 +123,7 @@ jobs:
             echo "No version changes detected - version already set to $VERSION"
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release version $VERSION"
+            git commit -m "release: set version $VERSION"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -270,7 +270,7 @@ jobs:
           # Commit as a second commit on the release branch. The tag (already
           # created and pushed on the first commit) is unaffected by this commit.
           git add pom.xml core/pom.xml processor/pom.xml example/pom.xml example-custom-generator/pom.xml
-          git commit -m "chore: prepare next version $NEXT_VERSION"
+          git commit -m "release: prepare next version $NEXT_VERSION"
 
           # Force-push the updated branch so the remote has both commits.
           # --force-with-lease is safe: it only succeeds if the remote branch is
@@ -294,6 +294,6 @@ jobs:
             gh pr create \
               --base main \
               --head "$BRANCH" \
-              --title "chore: release $VERSION and prepare $NEXT_VERSION" \
+              --title "Finalization PR: release $VERSION and prepare $NEXT_VERSION" \
               --body "Automated release of v$VERSION plus next-snapshot bump to \`$NEXT_VERSION\`. Review and merge to update \`main\`; created via PR so branch protection is not bypassed."
           fi


### PR DESCRIPTION
## Rename release pipeline commit messages and PR title from chore to release

### Problem

The release workflow used the conventional-commit type `chore` for its automated commits and PR title. `chore` implies routine maintenance (e.g., dependency bumps, formatting), which is misleading for a release finalization — both in the git history and in the PR review queue.

### Changes

**`.github/workflows/maven-central-release.yml`** (only changed file)

| What | Before | After |
|------|--------|-------|
| Commit 1 message | `chore: release version $VERSION` | `release: set version $VERSION` |
| Commit 2 message | `chore: prepare next version $NEXT_VERSION` | `release: prepare next version $NEXT_VERSION` |
| PR title | `chore: release $VERSION and prepare $NEXT_VERSION` | `Finalization PR: release $VERSION and prepare $NEXT_VERSION` |
| Branch name | `release/v$VERSION` | `release/v$VERSION` (unchanged) |
| GitHub Release title | `Release $VERSION` | `Release $VERSION` (unchanged) |

### Rationale

- `release:` is the appropriate conventional-commit type for version bumps and release preparation
- `Finalization PR:` makes the PR immediately recognizable in the review queue as the final step of a release
- Branch name `release/v$VERSION` is already clear and was not changed

### Verification

- Only 3 lines changed (3 insertions, 3 deletions)
- YAML structure unchanged — only string values modified

---